### PR TITLE
Fixes bug related to token validation

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -17,7 +17,9 @@ export function useShoppingListData(listId) {
 	const [data, setData] = useState(initialState);
 
 	useEffect(() => {
-		if (!listId) return;
+		// "/" is used by Firestore as a path separator and causes the app to crash when enter into the token field
+		// this restriction prevents communication with the database when "/" is used
+		if (!listId || listId.includes("/")) return;
 
 		// When we get a listId, we use it to subscribe to real-time updates
 		// from Firestore.

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -17,9 +17,8 @@ export function useShoppingListData(listId) {
 	const [data, setData] = useState(initialState);
 
 	useEffect(() => {
-		// "/" is used by Firestore as a path separator and causes the app to crash when enter into the token field
-		// this restriction prevents communication with the database when "/" is used
-		if (!listId || listId.includes("/")) return;
+		// in the Home component an invalid token is set to null and any calls to Firestore are skipped
+		if (!listId) return;
 
 		// When we get a listId, we use it to subscribe to real-time updates
 		// from Firestore.

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,6 +1,6 @@
-const Button = ({ ariaLabel, label, onClick, type }) => {
+const Button = ({ ariaLabel, label, onClick, type, isDisabled }) => {
 	return (
-		<button aria-label={ariaLabel} type={type} onClick={onClick}>
+		<button aria-label={ariaLabel} type={type} onClick={onClick} disabled={isDisabled}>
 			{label}
 		</button>
 	);

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -3,7 +3,6 @@ import Button from '../components/Button';
 import './Home.css';
 import { useState, useRef } from 'react';
 import { addNewListToFirestore, useShoppingListData } from '../api/firebase';
-import { sanitizeInput } from '../utils/sanitizeInput';
 
 export function Home({ setListToken }) {
 
@@ -12,6 +11,7 @@ export function Home({ setListToken }) {
 	
 	const [tokenInput, setTokenInput] = useState("");
 	const [errorMessage, setErrorMessage] = useState("");
+	const [isTokenValid, setIsTokenValid] = useState(false)
 	
 	
 	// OPTION: A - NEW (EMPTY) LIST IS ONLY SAVED TO LOCAL STORAGE
@@ -34,34 +34,20 @@ export function Home({ setListToken }) {
 		}
 	};
 
-	// IMPORT useShoppingListData FROM Firebase.js TO TEST WHETHER THE tokenInput IS VALID
-	const sharedListData = useShoppingListData(tokenInput)
-
-	const submitTokenInput = (event) => {
-		event.preventDefault();
-		
-		if(tokenInput.trim() === "") {
-			setErrorMessage("Please, enter 3-word token.");
-			setTimeout(() => {
-				setErrorMessage("");
-			}, 7000);
-			return;
-		} 
-
-		if(sharedListData.length === 0) {
-			setErrorMessage("The list does not exist. Please try again.");
-			setTimeout(() => {
-				setErrorMessage("");
-			}, 7000);
-			return;
-		} 
-
-		setListToken(tokenInput)
-	}
-
 	const handleInputChange = (event) => {
-		const sanitizedInput = sanitizeInput(event.target.value);
-		setTokenInput(sanitizedInput);
+		const tokenInput = event.target.value;
+		setTokenInput(tokenInput);
+
+		const tokenWords = tokenInput.split(' ').filter(word => word !== '');
+		setIsTokenValid(tokenWords.length === 3);
+
+		if (/[^a-zA-Z\s]/.test(tokenInput)) {
+			setErrorMessage("Please use only letters!");
+			setIsTokenValid(false);
+			setTimeout(() => {
+				setErrorMessage("");
+			}, 5000);
+		}
 	};
 	  
 
@@ -71,15 +57,49 @@ export function Home({ setListToken }) {
 		tokenInputRef.current.focus();
 	}
 
+	// IMPORT useShoppingListData FROM Firebase.js TO TEST WHETHER THE tokenInput IS VALID
+
+	const token = tokenInput.trim().toLowerCase()
+	const sharedListData = useShoppingListData(token)
+
+	const submitTokenInput = (event) => {
+		event.preventDefault();
+
+		if(sharedListData.length === 0) {
+			setErrorMessage("The list does not exist. Please try again.");
+			setTimeout(() => {
+				setErrorMessage("");
+			}, 7000);
+			return;
+		} 
+
+		setListToken(token)
+	}
+
+	const handleEnterKey = (event) => {
+		if (event.key === "Enter") {
+			event.preventDefault()
+			if (!isTokenValid) {
+				setErrorMessage('A token must contain exactly three words separated by a space.')
+				setTimeout(() => {
+					setErrorMessage("");
+				}, 7000);
+			} else {
+				submitTokenInput(event)
+			}
+		}
+	}
+	
+
 	return (
 		<div className="Home">
 			<Button label="Create New List" onClick={createNewList} />
 			<p>-or-</p>
-			<p>Join an existing shopping list by entering a three word token.</p>
+			<p>Join an existing shopping list.</p>
 
 			<form onSubmit={submitTokenInput}>
 				<label htmlFor="tokenInput">
-				Enter token:
+				Enter a 3-word token (example: "word word word"):
 				<br />
 					<input
 						type="text"
@@ -87,13 +107,19 @@ export function Home({ setListToken }) {
 						id="tokenInput"
 						value={tokenInput}
 						onChange={handleInputChange}
+						onKeyDown={handleEnterKey}
 						ref={tokenInputRef}
 					/>
 					
 				</label>
 				<Button label="X" type="reset" ariaLabel="Clear token input" onClick={clearTokenInput}/>
 				<br />
-				<Button label="Join" type="submit" ariaLabel="Join shared shopping list"/>
+				<Button 
+					label="Join" 
+					type="submit" 
+					ariaLabel="Join shared shopping list"
+					isDisabled={!isTokenValid}
+				/>
 			</form>
 			
 			<div aria-live="polite">

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -42,7 +42,6 @@ export function Home({ setListToken }) {
 		setIsTokenValid(tokenWords.length === 3);
 
 		// test for all non-letter characters; 
-		// please note: it does not work for '/', but do not panic! see useShoppingListData function in firestore.js for solution
 		if (/[^a-zA-Z\s]/.test(tokenInput)) {
 			setErrorMessage("Please use only letters!");
 			setIsTokenValid(false);
@@ -63,8 +62,8 @@ export function Home({ setListToken }) {
 	
 	// trim spaces at both ends of the token; keep only one space between words; turn all letters to lower case
 	const token = tokenInput.trim().replace(/\s+/g, ' ').toLowerCase();
-	// IMPORT useShoppingListData FROM Firebase.js TO TEST WHETHER THE tokenInput IS VALID
-	const sharedListData = useShoppingListData(token)
+	// allow calls to Firebase only if the token is valid
+	const sharedListData = useShoppingListData(isTokenValid ? token : null)
 
 	const submitTokenInput = (event) => {
 		event.preventDefault();

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -58,9 +58,10 @@ export function Home({ setListToken }) {
 		tokenInputRef.current.focus();
 	}
 
+	
+	// trim spaces at both ends of the token; keep only one space between words; turn all letters to lower case
+	const token = tokenInput.trim().replace(/\s+/g, ' ').toLowerCase();
 	// IMPORT useShoppingListData FROM Firebase.js TO TEST WHETHER THE tokenInput IS VALID
-
-	const token = tokenInput.trim().toLowerCase()
 	const sharedListData = useShoppingListData(token)
 
 	const submitTokenInput = (event) => {

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -42,7 +42,7 @@ export function Home({ setListToken }) {
 		setIsTokenValid(tokenWords.length === 3);
 
 		// test for all non-letter characters; 
-		// please note: it does not work for '/'. see useShoppingListData function in firestore.js
+		// please note: it does not work for '/', but do not panic! see useShoppingListData function in firestore.js for solution
 		if (/[^a-zA-Z\s]/.test(tokenInput)) {
 			setErrorMessage("Please use only letters!");
 			setIsTokenValid(false);

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -37,16 +37,18 @@ export function Home({ setListToken }) {
 	const handleInputChange = (event) => {
 		const tokenInput = event.target.value;
 
+		// test for a three-word token
 		const tokenWords = tokenInput.split(' ').filter(word => word !== '');
 		setIsTokenValid(tokenWords.length === 3);
 
-		// test for all non-letter characters with the exception of '/'. see useShoppingListData function in firestore.js
+		// test for all non-letter characters; 
+		// please note: it does not work for '/'. see useShoppingListData function in firestore.js
 		if (/[^a-zA-Z\s]/.test(tokenInput)) {
 			setErrorMessage("Please use only letters!");
 			setIsTokenValid(false);
 			setTimeout(() => {
 				setErrorMessage("");
-			}, 5000);
+			}, 7000);
 		}
 		setTokenInput(tokenInput);
 	};

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -36,11 +36,11 @@ export function Home({ setListToken }) {
 
 	const handleInputChange = (event) => {
 		const tokenInput = event.target.value;
-		setTokenInput(tokenInput);
 
 		const tokenWords = tokenInput.split(' ').filter(word => word !== '');
 		setIsTokenValid(tokenWords.length === 3);
 
+		// test for all non-letter characters with the exception of '/'. see useShoppingListData function in firestore.js
 		if (/[^a-zA-Z\s]/.test(tokenInput)) {
 			setErrorMessage("Please use only letters!");
 			setIsTokenValid(false);
@@ -48,6 +48,7 @@ export function Home({ setListToken }) {
 				setErrorMessage("");
 			}, 5000);
 		}
+		setTokenInput(tokenInput);
 	};
 	  
 


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._

## Description

We removed the `sanitizeInput` function from the `Home` component and introduced the following safeguards:
- disabling the `Join` button while the input is invalid
- testing for a three-word token
- testing for and alerting users of non-letter characters
- removing extra spaces from user inputs
- making inputs case-insensitive
- allowing calls to Firebase only if the token is valid

Because "/" is used by Firestore as a path separator, it caused the app to crash when entered into the token field. By checking  a token's validity before passing it to the `useShoppingListData` we now prevent communication with the database when "/" is used.

While the button is inactive, we allow users to press the `Enter` key and receive an error message. This feature should enhance accessibility for screen reader users.

## Related Issue

closes #23

## Acceptance Criteria

- [ ] Invalid characters trigger a warning of an invalid token
- [ ] The submit button is disabled until the input is valid
- [ ] Token name can be case insensitive

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|  ✓  | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

![image](https://github.com/the-collab-lab/tcl-63-smart-shopping-list/assets/115652409/af2aef85-04cb-4065-9178-8248cb81750d)

### After

![image](https://github.com/the-collab-lab/tcl-63-smart-shopping-list/assets/115652409/e6676eca-d351-477f-a8c8-446d3ab417c0)


## Testing Steps / QA Criteria

To pull our branch locally, run `git pull origin at-cm-issue27BugFix`
Next, run `git checkout at-cm-issue27BugFix`
Launch the app with `npm start`

### Ways to test:
- When landing on the `Home` page, the `Join` button should be inactive.
- Enter any non-letter character and an error message should appear on the screen for 7 seconds.
- The `Join` button becomes active as the user starts typing the 3rd word, but changes to disabled again if a non-letter character is entered or more words are added
- Press the `Enter` key while the button is disabled. It should trigger an error message.
- Testing with ` my    test  LIST  ` (notice the extra spaces!) should open the default `my test list`.

### Please note: 
Extra spaces between the words or at the beginning or end of the token input are dealt with by 
the `handleInputChange` function and will not trigger an error message.

