### PR TITLE
Calculate next purchase date

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -101,54 +101,55 @@ export async function updateItem(listId, itemId, checked) {
 	const checkedDateLastPurchased = checked ? today : dateLastPurchased;
 
 	if (!checkedDateLastPurchased) {
+		console.error('Could not update');
 		return;
-	} else {
-		const dateNextPurchasedAsDate = dateNextPurchased.toDate();
+	}
 
-		/**
-		 * Calculate the previous estimate for purchase
-		 * based on historical data
-		 */
-		const previousEstimate = getDaysBetweenDates(
-			checkedDateLastPurchased,
-			dateNextPurchasedAsDate,
-		);
+	const dateNextPurchasedAsDate = dateNextPurchased.toDate();
 
-		/**
-		 * Calculate the days since the last transaction,
-		 * considering either date last purchased or the created date
-		 */
-		const daysSinceLastTransaction = getDaysBetweenDates(
-			today,
-			checkedDateLastPurchased,
-		);
+	/**
+	 * Calculate the previous estimate for purchase
+	 * based on historical data
+	 */
+	const previousEstimate = getDaysBetweenDates(
+		checkedDateLastPurchased,
+		dateNextPurchasedAsDate,
+	);
 
-		let daysTillNextPurchase = calculateEstimate(
-			previousEstimate,
-			daysSinceLastTransaction,
-			totalPurchases,
-		);
+	/**
+	 * Calculate the days since the last transaction,
+	 * considering either date last purchased or the created date
+	 */
+	const daysSinceLastTransaction = getDaysBetweenDates(
+		today,
+		checkedDateLastPurchased,
+	);
 
-		// Ensure that the next purchase date is at least one day in the future
-		if (daysTillNextPurchase <= 0) {
-			daysTillNextPurchase = 1;
-		}
+	let daysTillNextPurchase = calculateEstimate(
+		previousEstimate,
+		daysSinceLastTransaction,
+		totalPurchases,
+	);
 
-		if (dateNextPurchasedAsDate < checkedDateLastPurchased) {
-			// Set checked to false so the item can be purchased again
-			checked = false;
-		}
+	// Ensure that the next purchase date is at least one day in the future
+	if (daysTillNextPurchase <= 0) {
+		daysTillNextPurchase = 1;
+	}
 
-		try {
-			return updateDoc(itemRef, {
-				dateLastPurchased: checkedDateLastPurchased,
-				dateNextPurchased: getFutureDate(daysTillNextPurchase),
-				totalPurchases: totalPurchases + 1,
-				checked: checked,
-			});
-		} catch (error) {
-			console.log('updateDoc error', error);
-		}
+	if (dateNextPurchasedAsDate < checkedDateLastPurchased) {
+		// Set checked to false so the item can be purchased again
+		checked = false;
+	}
+
+	try {
+		return updateDoc(itemRef, {
+			dateLastPurchased: checkedDateLastPurchased,
+			dateNextPurchased: getFutureDate(daysTillNextPurchase),
+			totalPurchases: totalPurchases + 1,
+			checked: checked,
+		});
+	} catch (error) {
+		console.log('updateDoc error', error);
 	}
 }
 

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -93,14 +93,16 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 export async function updateItem(listId, itemId, checked) {
 	const itemRef = doc(db, listId, itemId);
 	const itemDoc = await getDoc(itemRef);
-	const { dateCreated, dateLastPurchased, dateNextPurchased, totalPurchases } =
+	const { dateLastPurchased, dateNextPurchased, totalPurchases } =
 		itemDoc.data();
 
 	const today = new Date();
 
 	const checkedDateLastPurchased = checked ? today : dateLastPurchased;
 
-	if (checkedDateLastPurchased) {
+	if (!checkedDateLastPurchased) {
+		return;
+	} else {
 		const dateNextPurchasedAsDate = dateNextPurchased.toDate();
 
 		/**
@@ -118,7 +120,7 @@ export async function updateItem(listId, itemId, checked) {
 		 */
 		const daysSinceLastTransaction = getDaysBetweenDates(
 			today,
-			checkedDateLastPurchased || dateCreated,
+			checkedDateLastPurchased,
 		);
 
 		let daysTillNextPurchase = calculateEstimate(

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -160,7 +160,6 @@ export async function updateItem(listId, itemId, checked) {
 				dateLastPurchased: dateLastPurchased,
 				dateNextPurchased: newDateNextPurchased,
 				totalPurchases: totalPurchases,
-				checked: checked,
 			});
 		} catch (error) {
 			console.log('Unchecked item update error:', error);

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -111,8 +111,6 @@ export async function updateItem(listId, itemId, checked) {
 			dateNextPurchasedAsDate,
 		);
 
-		console.log('previous estimate', previousEstimate);
-
 		/**
 		 * Calculate the days since the last transaction,
 		 * considering either last purchased or the created date
@@ -121,8 +119,6 @@ export async function updateItem(listId, itemId, checked) {
 			new Date(),
 			checkedDateLastPurchased || dateCreated,
 		);
-
-		console.log('days since last transaction', daysSinceLastTransaction);
 
 		// Calculate the remaining days until the next purchase
 		let remainingDays = calculateEstimate(
@@ -135,10 +131,6 @@ export async function updateItem(listId, itemId, checked) {
 		if (remainingDays <= 0) {
 			remainingDays = 1;
 		}
-
-		console.log('remaining days', remainingDays);
-
-		console.log('get future date', getFutureDate(remainingDays));
 
 		if (dateNextPurchasedAsDate < checkedDateLastPurchased) {
 			// Set checked to false so the item can be purchased again

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -10,3 +10,30 @@ const ONE_DAY_IN_MILLISECONDS = 86400000;
 export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
+
+/**
+ * Calculates the number of days between two JS Date objects.
+ * @example
+ * // Returns the number of days that have passed between the two dates.
+ * const startDate = new Date("2023-09-15");
+ * const endDate = new Date("2023-09-24");
+ * getDaysBetweenDates(startDate, endDate); // Output is 9 (days)
+ * @param {Date} startDate - The starting date.
+ * @param {Date} endDate - The ending date.
+ * @returns {number} - The number of days between the start and end dates.
+ */
+export function getDaysBetweenDates(startDate, endDate) {
+	try {
+		if (startDate instanceof Date && endDate instanceof Date) {
+			const days_between_in_milliseconds =
+				endDate.getTime() - startDate.getTime();
+
+			// Using Math.round() to ensure that fractional days are rounded to the nearest whole day
+			return Math.round(days_between_in_milliseconds / ONE_DAY_IN_MILLISECONDS);
+		} else {
+			console.log('Not a date');
+		}
+	} catch (error) {
+		console.log('An error happened', error);
+	}
+}

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -29,7 +29,9 @@ export function getDaysBetweenDates(startDate, endDate) {
 				endDate.getTime() - startDate.getTime();
 
 			// Using Math.round() to ensure that fractional days are rounded to the nearest whole day
-			return Math.round(days_between_in_milliseconds / ONE_DAY_IN_MILLISECONDS);
+			return Math.abs(
+				Math.round(days_between_in_milliseconds / ONE_DAY_IN_MILLISECONDS),
+			);
 		} else {
 			console.log(
 				`Not a date\nstartDate is of type: ${typeof startDate}\nendDate is of type: ${typeof endDate}`,

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -25,12 +25,11 @@ export function getFutureDate(offset) {
 export function getDaysBetweenDates(startDate, endDate) {
 	try {
 		if (startDate instanceof Date && endDate instanceof Date) {
-			const days_between_in_milliseconds =
-				endDate.getTime() - startDate.getTime();
+			const daysBetweenInMilliseconds = endDate.getTime() - startDate.getTime();
 
 			// Using Math.round() to ensure that fractional days are rounded to the nearest whole day
 			return Math.abs(
-				Math.round(days_between_in_milliseconds / ONE_DAY_IN_MILLISECONDS),
+				Math.round(daysBetweenInMilliseconds / ONE_DAY_IN_MILLISECONDS),
 			);
 		} else {
 			console.log(

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -31,9 +31,11 @@ export function getDaysBetweenDates(startDate, endDate) {
 			// Using Math.round() to ensure that fractional days are rounded to the nearest whole day
 			return Math.round(days_between_in_milliseconds / ONE_DAY_IN_MILLISECONDS);
 		} else {
-			console.log('Not a date');
+			console.log(
+				`Not a date\nstartDate is of type: ${typeof startDate}\nendDate is of type: ${typeof endDate}`,
+			);
 		}
 	} catch (error) {
-		console.log('An error happened', error);
+		console.error('An error happened', error);
 	}
 }


### PR DESCRIPTION
## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

In order to advise users about when to purchase things, the app needed to be able to calculate that guess and store it for a future date.

To achieve this, we used the `calculateEstimate` function from the `@the-collab-lab/shopping-list-utils` module. This function helps determine how many days in the future a purchase should happen. In order to use `calculateEstimate`, we gather information about how many days have passed since the last purchase of the item.

### Steps Taken

- Created a `getDaysBetweenDates` function in `dates.js` that calculates the number of days between two JavaScript Dates by using the `getTime()` method, which provides a millisecond representation of each date.
- Converted the `dateNextPurchased` from a **Firestore Timestamp object** to a JavaScript Date using the `.toDate()` method (see [the Firestore docs](https://firebase.google.com/docs/reference/js/v8/firebase.firestore.Timestamp#todate)).
- `calculateEstimate` needs **three** arguments, so we used the `getDaysBetweenDates` function to calculate the *first two arguments* required for the `calculateEstimate` function.
- We stored the result of `calculateEstimate` in a variable (which represents the remaining days until the next purchase) and since it initially returns a **number**, we needed to convert it to a Date format, which we achieved by using the `getFutureDate` function and saving it to the database as `dateNextPurchased`.

### Files Modified 

- utils/dates.js
- api/firebase.js

### Notes

If you'd like to understand how the `calculateEstimate` function works, please check the actual code [here](https://github.com/the-collab-lab/shopping-list-utils/blob/main/src/calculateEstimate/index.ts). 

## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->
closes #10 

## Acceptance Criteria

<!-- Include AC from the Github issue -->

- [x] When the user purchases an item, the item’s `dateNextPurchased` property is calculated using the `calculateEstimate` function and saved to the Firestore database
  - [x] `dateNextPurchased` is saved as **a date**, not a number
- [x] A `getDaysBetweenDates` function is exported from `utils/dates.js`  and imported into `api/firebase.js`
  - [x] This function takes two JavaScript Dates and return the number of days that have passed between them

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

<!-- If UI feature, take provide screenshots -->

Before, the `dateNextPurchased` was set to either 7, 14, or 30 days based on the input selected in `AddItem.jsx`. As a result, the date and time were saved in the database relative to the `dateCreated`.

![Date created vs dateNextPurchased comparison](https://github.com/the-collab-lab/tcl-63-smart-shopping-list/assets/54380958/a7a844f4-dac3-458a-adb9-3ed9c55fd6d4)

### After

<!-- If UI feature, take provide screenshots -->

Now, the `dateNextPurchased` is calculated relative to the `dateLastPurchased` using the `calculateEstimate` function. However, when an item is initially created, the `dateNextPurchased` is still determined based on user input (7, 14, or 30 days).

![dateLastPurchased vs dateNextPurchased comparison](https://github.com/the-collab-lab/tcl-63-smart-shopping-list/assets/54380958/30c0d523-066e-40ef-829c-a58c10aa00db)


## Testing Steps / QA Criteria

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->

- To pull our branch locally, run `git pull origin at-rp-calculate-next-purchase-date` 
- Next, run `git checkout at-rp-calculate-next-purchase-date`
- Launch the app with `npm start`

There are two options to test this new feature:
1. Create a new item and choose either "Soon," "Kind of Soon," or "Not Soon." Then, locate that item in the database. After finding it, check the item in our app and review the database again. You will notice that the `dateNextPurchased` now corresponds to the `dateLastPurchased`, and their times are the same.
2. Check an unchecked item, and then examine the database for the `dateLastPurchased` and `dateNextPurchased` (their times will be the same, but the dates will be different).

If you want to go a step further, you can add a console.log to verify the accuracy of the calculations right after the `previousEstimate`, `daysSinceLastTransaction`, and `remainingDays` variables, like this:

```
console.log("previousEstimate", previousEstimate);
console.log("daysSinceLastTransaction", daysSinceLastTransaction);
```
After checking an item, verify the console to see the result of those variables.

### Notes

- When you check an item for the first time, it will no longer be calculated based on the 7, 14, or 30-day intervals. The `calculateEstimate` function is responsible for determining when the user needs to buy that item again.